### PR TITLE
* Add defines for supporting SSL and HTTPBridge and removing SUPEROBJ…

### DIFF
--- a/DUnit/UnitTestWebsockets.dpr
+++ b/DUnit/UnitTestWebsockets.dpr
@@ -14,7 +14,7 @@ program UnitTestWebsockets;
   {$APPTYPE CONSOLE}
 {$ENDIF}
 
-{$IFNDEF USE_JEDI_JCL} {$MESSAGE ERROR 'Must define "USE_JEDI_JCL" for location info of errors'} {$ENDIF}
+//{$IFNDEF USE_JEDI_JCL} {$MESSAGE ERROR 'Must define "USE_JEDI_JCL" for location info of errors'} {$ENDIF}
 
 {$R *.RES}
 

--- a/DUnit/mtTestWebSockets.pas
+++ b/DUnit/mtTestWebSockets.pas
@@ -156,7 +156,7 @@ begin
   //* client to server */
   received := '';
   IndyHTTPWebsocketServer1.SocketIO.OnEvent('TEST_EVENT',
-    procedure(const ASocket: ISocketIOContext; const aArgument: TSuperArray; const aCallbackObj: TSocketIOCallbackObj)
+    procedure(const ASocket: ISocketIOContext; const aArgument: TSuperArray; const aCallbackObj: ISocketIOCallback)
     begin
       received := aArgument.ToJson;
     end);
@@ -180,7 +180,7 @@ begin
   //* server to client */
   received := '';
   IndyHTTPWebsocketClient1.SocketIO.OnEvent('TEST_EVENT',
-    procedure(const ASocket: ISocketIOContext; const aArgument: TSuperArray; const aCallbackObj: TSocketIOCallbackObj)
+    procedure(const ASocket: ISocketIOContext; const aArgument: TSuperArray; const aCallbackObj: ISocketIOCallback)
     begin
       received := aArgument.ToJson;
     end);
@@ -205,12 +205,12 @@ begin
   //* client to server */
   FLastSocketIOMsg := '';
   IndyHTTPWebsocketServer1.SocketIO.OnSocketIOMsg :=
-    procedure(const ASocket: ISocketIOContext; const aText: string; const aCallback: TSocketIOCallbackObj)
+    procedure(const ASocket: ISocketIOContext; const aText: string; const aCallback: ISocketIOCallback)
     begin
       Abort;
     end;
   IndyHTTPWebsocketClient1.SocketIO.Send('test message',
-    procedure(const ASocket: ISocketIOContext; const aJSON: ISuperObject; const aCallback: TSocketIOCallbackObj)
+    procedure(const ASocket: ISocketIOContext; const aJSON: ISuperObject; const aCallback: ISocketIOCallback)
     begin
       FLastSocketIOMsg := aJSON.AsString;
     end);
@@ -223,7 +223,7 @@ begin
 
   FLastSocketIOMsg := '';
   IndyHTTPWebsocketClient1.SocketIO.Send('test message',
-    procedure(const ASocket: ISocketIOContext; const aJSON: ISuperObject; const aCallback: TSocketIOCallbackObj)
+    procedure(const ASocket: ISocketIOContext; const aJSON: ISuperObject; const aCallback: ISocketIOCallback)
     begin
       Assert(False, 'should go to error handling callback');
       FLastSocketIOMsg := 'error';
@@ -252,7 +252,7 @@ begin
   //* client to server */
   FLastSocketIOMsg := '';
   IndyHTTPWebsocketServer1.SocketIO.OnSocketIOMsg :=
-    procedure(const ASocket: ISocketIOContext; const aText: string; const aCallback: TSocketIOCallbackObj)
+    procedure(const ASocket: ISocketIOContext; const aText: string; const aCallback: ISocketIOCallback)
     begin
       FLastSocketIOMsg := aText;
     end;
@@ -267,7 +267,7 @@ begin
   //* server to client */
   FLastSocketIOMsg := '';
   IndyHTTPWebsocketClient1.SocketIO.OnSocketIOMsg :=
-    procedure(const ASocket: ISocketIOContext; const aText: string; const aCallback: TSocketIOCallbackObj)
+    procedure(const ASocket: ISocketIOContext; const aText: string; const aCallback: ISocketIOCallback)
     begin
       FLastSocketIOMsg := aText;
     end;

--- a/IdHTTPWebsocketClient.pas
+++ b/IdHTTPWebsocketClient.pas
@@ -1,23 +1,13 @@
 unit IdHTTPWebsocketClient;
-
 interface
-
+{$I wsdefines.pas}
 uses
   Classes,
   IdHTTP,
-  {$IF CompilerVersion <= 21.0}  //D2010
-  IdHashSHA1,
-  {$else}
   Types,
   IdHashSHA,                     //XE3 etc
-  {$IFEND}
   IdIOHandler,
   IdIOHandlerWebsocket,
-  {$ifdef FMX}
-  FMX.Types,
-  {$ELSE}
-  ExtCtrls,
-  {$ENDIF}
   IdWinsock2, Generics.Collections, SyncObjs,
   IdSocketIOHandling;
 
@@ -557,7 +547,11 @@ begin
     begin
       Request.Clear;
       Request.Connection := 'keep-alive';
+      {$IFDEF WEBSOCKETSSL}
+      sURL := Format('https://%s:%d/socket.io/1/', [Host, Port]);
+      {$ELSE}
       sURL := Format('http://%s:%d/socket.io/1/', [Host, Port]);
+      {$ENDIF}
       strmResponse.Clear;
 
       ReadTimeout := 5 * 1000;

--- a/IdServerIOHandlerWebsocket.pas
+++ b/IdServerIOHandlerWebsocket.pas
@@ -1,16 +1,33 @@
 unit IdServerIOHandlerWebsocket;
-
 interface
-
+{$I wsdefines.pas}
 uses
-  Classes,
-  IdServerIOHandlerStack, IdIOHandlerStack, IdGlobal, IdIOHandler, IdYarn, IdThread, IdSocketHandle,
-  IdIOHandlerWebsocket;
+  Classes
+  , IdServerIOHandlerStack
+  , IdIOHandlerStack
+  , IdGlobal
+  , IdIOHandler
+  , IdYarn
+  , IdThread
+  , IdSocketHandle
+  //
+  , IdIOHandlerWebsocket
+  {$IFDEF WEBSOCKETSSL}
+  , IdSSLOpenSSL
+  {$ENDIF}
+  ;
 
 type
+  {$IFDEF WEBSOCKETSSL}
+  TIdServerIOHandlerWebsocket = class(TIdServerIOHandlerSSLOpenSSL)
+  {$ELSE}
   TIdServerIOHandlerWebsocket = class(TIdServerIOHandlerStack)
+  {$ENDIF}
   protected
     procedure InitComponent; override;
+    {$IFDEF WEBSOCKETSSL}
+    function CreateOpenSSLSocket:TIdSSLIOHandlerSocketOpenSSL; override;
+    {$ENDIF}
   public
     function Accept(ASocket: TIdSocketHandle; AListenerThread: TIdThread;
       AYarn: TIdYarn): TIdIOHandler; override;
@@ -20,6 +37,13 @@ type
 implementation
 
 { TIdServerIOHandlerStack_Websocket }
+
+{$IFDEF WEBSOCKETSSL}
+function TIdServerIOHandlerWebsocket.CreateOpenSSLSocket:TIdSSLIOHandlerSocketOpenSSL;
+begin
+  Result := TIdIOHandlerWebsocket.Create(nil);
+end;
+{$ENDIF}
 
 function TIdServerIOHandlerWebsocket.Accept(ASocket: TIdSocketHandle;
   AListenerThread: TIdThread; AYarn: TIdYarn): TIdIOHandler;
@@ -35,18 +59,22 @@ end;
 procedure TIdServerIOHandlerWebsocket.InitComponent;
 begin
   inherited InitComponent;
+  {$IFNDEF WEBSOCKETSSL}
   IOHandlerSocketClass := TIdIOHandlerWebsocket;
+  {$ENDIF}
 end;
 
 function TIdServerIOHandlerWebsocket.MakeClientIOHandler(
   ATheThread: TIdYarn): TIdIOHandler;
 begin
   Result := inherited MakeClientIOHandler(ATheThread);
+  {$IFNDEF WEBSOCKETSSL}
   if Result <> nil then
   begin
     (Result as TIdIOHandlerWebsocket).IsServerSide := True; //server must not mask, only client
     (Result as TIdIOHandlerWebsocket).UseNagle := False;
   end;
+  {$ENDIF}
 end;
 
 end.

--- a/IdServerWebsocketContext.pas
+++ b/IdServerWebsocketContext.pas
@@ -1,16 +1,22 @@
 unit IdServerWebsocketContext;
-
 interface
-
+{$I wsdefines.pas}
 uses
-  Classes,
-  IdCustomTCPServer, IdIOHandlerWebsocket,
-  IdServerBaseHandling, IdServerSocketIOHandling, IdContext;
+  Classes, strUtils
+  , IdContext
+  , IdCustomTCPServer
+  , IdCustomHTTPServer
+  //
+  , IdIOHandlerWebsocket
+  , IdServerBaseHandling
+  , IdServerSocketIOHandling
+  ;
 
 type
   TIdServerWSContext = class;
 
-  TWebsocketChannelRequest = procedure(const AContext: TIdServerWSContext; aType: TWSDataType; const strmRequest, strmResponse: TMemoryStream) of object;
+  TWebSocketUpgradeEvent = procedure(const AContext: TIdServerWSContext; ARequestInfo: TIdHTTPRequestInfo; var Accept:boolean) of object;
+  TWebsocketChannelRequest = procedure(const AContext: TIdServerWSContext; var aType:TWSDataType; const strmRequest, strmResponse: TMemoryStream) of object;
 
   TIdServerWSContext = class(TIdServerContext)
   private
@@ -25,6 +31,7 @@ type
     FWebSocketExtensions: string;
     FCookie: string;
     //FSocketIOPingSend: Boolean;
+    fOnWebSocketUpgrade: TWebSocketUpgradeEvent;
     FOnCustomChannelExecute: TWebsocketChannelRequest;
     FSocketIO: TIdServerSocketIOHandling;
     FOnDestroy: TIdContextEvent;
@@ -50,13 +57,11 @@ type
     property WebSocketVersion   : Integer read FWebSocketVersion write FWebSocketVersion;
     property WebSocketExtensions: string  read FWebSocketExtensions write FWebSocketExtensions;
   public
+    property OnWebSocketUpgrade: TWebsocketUpgradeEvent read FOnWebSocketUpgrade write FOnWebSocketUpgrade;
     property OnCustomChannelExecute: TWebsocketChannelRequest read FOnCustomChannelExecute write FOnCustomChannelExecute;
   end;
 
 implementation
-
-uses
-  StrUtils;
 
 { TIdServerWSContext }
 

--- a/IdServerWebsocketHandling.pas
+++ b/IdServerWebsocketHandling.pas
@@ -1,16 +1,24 @@
 unit IdServerWebsocketHandling;
-
 interface
-
+{$I wsdefines.pas}
 uses
-  IdContext, IdCustomHTTPServer,
+  Classes, StrUtils, SysUtils, DateUtils
+  , IdCoderMIME
+  , IdThread
+  , IdContext
+  , IdCustomHTTPServer
   {$IF CompilerVersion <= 21.0}  //D2010
-  IdHashSHA1,
+  , IdHashSHA1
   {$else}
-  IdHashSHA,                     //XE3 etc
+  , IdHashSHA                     //XE3 etc
   {$IFEND}
-  IdServerSocketIOHandling, IdServerWebsocketContext,
-  Classes, IdServerBaseHandling, IdIOHandlerWebsocket, IdSocketIOHandling;
+  , IdServerSocketIOHandling
+  //
+  , IdSocketIOHandling
+  , IdServerBaseHandling
+  , IdServerWebsocketContext
+  , IdIOHandlerWebsocket
+  ;
 
 type
   TIdServerSocketIOHandling_Ext = class(TIdServerSocketIOHandling)
@@ -19,7 +27,7 @@ type
   TIdServerWebsocketHandling = class(TIdServerBaseHandling)
   protected
     class procedure DoWSExecute(AThread: TIdContext; aSocketIOHandler: TIdServerSocketIOHandling_Ext);virtual;
-    class procedure HandleWSMessage(AContext: TIdServerWSContext; aType: TWSDataType;
+    class procedure HandleWSMessage(AContext: TIdServerWSContext; var aType: TWSDataType;
                                     aRequestStrm, aResponseStrm: TMemoryStream;
                                     aSocketIOHandler: TIdServerSocketIOHandling_Ext);virtual;
   public
@@ -30,10 +38,6 @@ type
   end;
 
 implementation
-
-uses
-  StrUtils, SysUtils, DateUtils,
-  IdCustomTCPServer, IdCoderMIME, IdThread;
 
 { TIdServerWebsocketHandling }
 
@@ -103,23 +107,20 @@ begin
             Continue;
           end;
 
-          if wscode = wdcText then
-            wstype := wdtText
-          else
-            wstype := wdtBinary;
+          if wscode = wdcText
+             then wstype := wdtText
+             else wstype := wdtBinary;
 
           HandleWSMessage(context, wstype, strmRequest, strmResponse, aSocketIOHandler);
 
           //write result back (of the same type: text or bin)
           if strmResponse.Size > 0 then
           begin
-            if wscode = wdcText then
-              context.IOHandler.Write(strmResponse, wdtText)
-            else
-              context.IOHandler.Write(strmResponse, wdtBinary)
+            if wstype = wdtText
+               then context.IOHandler.Write(strmResponse, wdtText)
+               else context.IOHandler.Write(strmResponse, wdtBinary)
           end
-          else
-            context.IOHandler.WriteData(nil, wdcPing);
+          else context.IOHandler.WriteData(nil, wdcPing);
         finally
           strmRequest.Free;
           strmResponse.Free;
@@ -152,9 +153,7 @@ begin
   end;
 end;
 
-class procedure TIdServerWebsocketHandling.HandleWSMessage(AContext: TIdServerWSContext; aType: TWSDataType;
-  aRequestStrm, aResponseStrm: TMemoryStream;
-  aSocketIOHandler: TIdServerSocketIOHandling_Ext);
+class procedure TIdServerWebsocketHandling.HandleWSMessage(AContext: TIdServerWSContext; var aType:TWSDataType; aRequestStrm, aResponseStrm: TMemoryStream; aSocketIOHandler: TIdServerSocketIOHandling_Ext);
 begin
   if AContext.IsSocketIO then
   begin
@@ -170,6 +169,7 @@ class function TIdServerWebsocketHandling.ProcessServerCommandGet(
   AThread: TIdServerWSContext; ARequestInfo: TIdHTTPRequestInfo;
   AResponseInfo: TIdHTTPResponseInfo): Boolean;
 var
+  Accept: Boolean;
   sValue, squid: string;
   context: TIdServerWSContext;
   hash: TIdHashSHA1;
@@ -243,6 +243,13 @@ begin
   begin
     Result  := True;  //handled
     context := AThread as TIdServerWSContext;
+
+    if Assigned(Context.OnWebSocketUpgrade) then
+     begin
+        Accept := True;
+        Context.OnWebSocketUpgrade(Context,ARequestInfo,Accept);
+        if not Accept then Abort;
+     end;
 
     //Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
     sValue := ARequestInfo.RawHeaders.Values['sec-websocket-key'];

--- a/IdWebsocketServer.pas
+++ b/IdWebsocketServer.pas
@@ -1,16 +1,41 @@
 unit IdWebsocketServer;
-
 interface
-
+{$I wsdefines.pas}
 uses
-  IdServerWebsocketHandling, IdServerSocketIOHandling, IdServerWebsocketContext,
-  IdHTTPServer, IdContext, IdCustomHTTPServer, Classes, IdIOHandlerWebsocket;
+  Classes
+  , IdStreamVCL
+  , IdGlobal
+  , IdWinsock2
+  , IdHTTPServer
+  , IdContext
+  , IdCustomHTTPServer
+  , IdHTTPWebBrokerBridge
+  //
+  , IdIOHandlerWebsocket
+  , IdServerIOHandlerWebsocket
+  , IdServerWebsocketContext
+  , IdServerWebsocketHandling
+  , IdServerSocketIOHandling
+  ;
 
 type
   TWebsocketMessageText = procedure(const AContext: TIdServerWSContext; const aText: string)  of object;
   TWebsocketMessageBin  = procedure(const AContext: TIdServerWSContext; const aData: TStream) of object;
 
+  {$IFDEF WEBSOCKETBRIDGE}
+  TMyIdHttpWebBrokerBridge = class(TidHttpWebBrokerBridge)
+  published
+    property OnCreatePostStream;
+    property OnDoneWithPostStream;
+    property OnCommandGet;
+  end;
+  {$ENDIF}
+
+  {$IFDEF WEBSOCKETBRIDGE}
+  TIdWebsocketServer = class(TMyIdHttpWebBrokerBridge)
+  {$ELSE}
   TIdWebsocketServer = class(TIdHTTPServer)
+  {$ENDIF}
   private
     FSocketIO: TIdServerSocketIOHandling_Ext;
     FOnMessageText: TWebsocketMessageText;
@@ -19,12 +44,13 @@ type
     function GetSocketIO: TIdServerSocketIOHandling;
     procedure SetWriteTimeout(const Value: Integer);
   protected
-    procedure DoCommandGet(AContext: TIdContext; ARequestInfo: TIdHTTPRequestInfo;
-     AResponseInfo: TIdHTTPResponseInfo); override;
+    function WebSocketCommandGet(AContext: TIdContext; ARequestInfo: TIdHTTPRequestInfo; AResponseInfo: TIdHTTPResponseInfo):boolean;
+    procedure DoCommandGet(AContext: TIdContext; ARequestInfo: TIdHTTPRequestInfo; AResponseInfo: TIdHTTPResponseInfo); override;
     procedure ContextCreated(AContext: TIdContext); override;
     procedure ContextDisconnected(AContext: TIdContext); override;
 
-    procedure WebsocketChannelRequest(const AContext: TIdServerWSContext; aType: TWSDataType; const aStrmRequest, aStrmResponse: TMemoryStream);
+    procedure WebsocketUpgradeRequest(const AContext: TIdServerWSContext; ARequestInfo: TIdHTTPRequestInfo; var Accept:boolean); virtual;
+    procedure WebsocketChannelRequest(const AContext: TIdServerWSContext; var aType:TWSDataType; const aStrmRequest, aStrmResponse: TMemoryStream); virtual;
   public
     procedure  AfterConstruction; override;
     destructor Destroy; override;
@@ -41,9 +67,6 @@ type
   end;
 
 implementation
-
-uses
-  IdServerIOHandlerWebsocket, IdStreamVCL, IdGlobal, Windows, IdWinsock2;
 
 { TIdWebsocketServer }
 
@@ -82,13 +105,20 @@ begin
   FSocketIO.Free;
 end;
 
-procedure TIdWebsocketServer.DoCommandGet(AContext: TIdContext;
-  ARequestInfo: TIdHTTPRequestInfo; AResponseInfo: TIdHTTPResponseInfo);
+function TIdWebsocketServer.WebSocketCommandGet(AContext: TIdContext;
+  ARequestInfo: TIdHTTPRequestInfo; AResponseInfo: TIdHTTPResponseInfo):boolean;
 begin
+  (AContext as TIdServerWSContext).OnWebSocketUpgrade := Self.WebSocketUpgradeRequest;
   (AContext as TIdServerWSContext).OnCustomChannelExecute := Self.WebsocketChannelRequest;
   (AContext as TIdServerWSContext).SocketIO               := FSocketIO;
 
-  if not TIdServerWebsocketHandling.ProcessServerCommandGet(AContext as TIdServerWSContext, ARequestInfo, AResponseInfo) then
+  Result := TIdServerWebsocketHandling.ProcessServerCommandGet(AContext as TIdServerWSContext, ARequestInfo, AResponseInfo);
+end;
+
+procedure TIdWebsocketServer.DoCommandGet(AContext: TIdContext;
+  ARequestInfo: TIdHTTPRequestInfo; AResponseInfo: TIdHTTPResponseInfo);
+begin
+  if not WebSocketCommandGet(AContext,ARequestInfo,AResponseInfo) then
     inherited DoCommandGet(AContext, ARequestInfo, AResponseInfo);
 end;
 
@@ -124,9 +154,12 @@ begin
   FWriteTimeout := Value;
 end;
 
-procedure TIdWebsocketServer.WebsocketChannelRequest(
-  const AContext: TIdServerWSContext; aType: TWSDataType; const aStrmRequest,
-  aStrmResponse: TMemoryStream);
+procedure TIdWebsocketServer.WebsocketUpgradeRequest(const AContext: TIdServerWSContext; ARequestInfo: TIdHTTPRequestInfo; var Accept:boolean);
+begin
+  Accept := True;
+end;
+
+procedure TIdWebsocketServer.WebsocketChannelRequest(const AContext: TIdServerWSContext; var aType:TWSDataType; const aStrmRequest,aStrmResponse: TMemoryStream);
 var s: string;
 begin
   if aType = wdtText then


### PR DESCRIPTION
Defines are defined in wsdefines.pas
Removing SUPEROBJECT allow to release under MPL license (which i expect)
Also fix
- bug : framing encoding when sending a frame in multiple parts (fin=false)
- bug : TIdIOHandlerWebsocket TIdIOHandlerWebsocket.ReadFrame _WaitByte ; may hang
  Other changes
- Refactoring of TIdServerWebsocketHandling.ProcessServerCommandGet for inheritance
- Add event (TIdServerWSContext) to accept or refuse upgrade (allow to check session cookie)
- Change TWebsocketChannelRequest var aType:TWSDataType to allow receiving in a mode and answering in an other

To use OpenSSL you need a modification in IdSSLOpenSSL to let overwrite TIdSSLIOHandlerSocketOpenSSL class
