### PR TITLE
fixed "Invalid frame continuation" exception when ping or pong frames arrive while also fragmented data frames are being received

### DIFF
--- a/IdIOHandlerWebsocket.pas
+++ b/IdIOHandlerWebsocket.pas
@@ -790,13 +790,28 @@ begin
         wdcPing:
         begin
           WriteData(iaReadBuffer, wdcPong);  //send pong + same data back
-          lFirstDataCode := lDataCode;
-          //bFIN := False; //ignore ping when we wait for data?
+
+          //ping received, ignore while were are receiving fragmented frames
+          if (lFirstDataCode in [wdcText, wdcBinary]) then
+          begin
+            bFIN := False;
+          end
+          else
+          begin
+            lFirstDataCode := lDataCode;
+          end;
         end;
         wdcPong:
         begin
-           //pong received, ignore;
-          lFirstDataCode := lDataCode;
+          //pong received, ignore while were are receiving fragmented frames
+          if (lFirstDataCode in [wdcText, wdcBinary]) then
+          begin
+            bFIN := False;
+          end
+          else
+          begin
+            lFirstDataCode := lDataCode;
+          end;
         end;
       end;
     end


### PR DESCRIPTION
Fixed a possible `Invalid frame continuation. Data = ...` exception in `TIdIOHandlerWebsocket.ReadMessage`:

When a large message is being received that comes in as several fragments, it may happen that a `wdcPong` is also received inbetween of the fragments. This results in `bFIN` being true and the function being leaved.
When the function is entered again for the next fragment, `lFirstDataCode` is `wdcNone`. This results in the exception being thrown in the `wdcContinuation` of the `case` statement.

Solution: Reset `bFIN` to false and therefore ignore the `wdcPong` as long as were are still receiving fragments. My client doesn't send pings so I didn't see it in my scenario but the same should apply for `wdcPing` frames.